### PR TITLE
Add additional hosts to pdfjs viewer domains list.

### DIFF
--- a/app/assets/javascripts/pdfjs_viewer/viewer.js
+++ b/app/assets/javascripts/pdfjs_viewer/viewer.js
@@ -6456,6 +6456,8 @@ var pdfjsWebLibs;
    var validateFileURL;
    var HOSTED_VIEWER_ORIGINS = [
     'null',
+    'https://attachments.screendoor-marius-uat.uat.cityba.se',
+    'https://attachments.screendoor.uat.cityba.se',
     'https://attachments.dobt.dev',
     'https://attachments.staging.dobt.co',
     'https://attachments.dobt.co',


### PR DESCRIPTION
We need to whitelist a few other domains so that pdf js viewer works in the k8s cluster.

We'll probably need a regex here instead but I deferred that decision to later.